### PR TITLE
update the example code to the 0.5.x adapter api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function _ADAPTER_NAME_Adapter(config, Juttle) {
+function _ADAPTER_NAME_Adapter(config) {
     return {
         name: '_ADAPTER_NAME_',
         read: require('./read'),

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,7 +1,8 @@
 'use strict';
 
-let AdapterRead = require('juttle/lib/runtime/adapter-read');
-let logger = require('juttle/lib/logger').getLogger('_ADAPTER_NAME_-read');
+/* global JuttleAdapterAPI */
+let AdapterRead = JuttleAdapterAPI.AdapterRead;
+let logger = JuttleAdapterAPI.getLogger('_ADAPTER_NAME_-read');
 
 class Read_ADAPTER_NAME_ extends AdapterRead {
     constructor(options, params) {

--- a/lib/read.js
+++ b/lib/read.js
@@ -2,16 +2,15 @@
 
 /* global JuttleAdapterAPI */
 let AdapterRead = JuttleAdapterAPI.AdapterRead;
-let logger = JuttleAdapterAPI.getLogger('_ADAPTER_NAME_-read');
 
 class Read_ADAPTER_NAME_ extends AdapterRead {
     constructor(options, params) {
         super(options, params);
-        logger.debug('initializing read _ADAPTER_NAME_');
+        this.logger.debug('initializing read _ADAPTER_NAME_');
         throw Error('implement me');
     }
 
-    read(from, to, limit, state) { 
+    read(from, to, limit, state) {
         throw Error('implement me');
     }
 }

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,7 +1,8 @@
 'use strict';
 
-let AdapterWrite = require('juttle/lib/runtime/adapter-write');
-let logger = require('juttle/lib/logger').getLogger('_ADAPTER_NAME_-write');
+/* global JuttleAdapterAPI */
+let AdapterWrite = JuttleAdapterAPI.AdapterWrite;
+let logger = JuttleAdapterAPI.getLogger('_ADAPTER_NAME_-write');
 
 class Write_ADAPTER_NAME_ extends AdapterWrite {
     constructor(options, params) {

--- a/lib/write.js
+++ b/lib/write.js
@@ -2,16 +2,15 @@
 
 /* global JuttleAdapterAPI */
 let AdapterWrite = JuttleAdapterAPI.AdapterWrite;
-let logger = JuttleAdapterAPI.getLogger('_ADAPTER_NAME_-write');
 
 class Write_ADAPTER_NAME_ extends AdapterWrite {
     constructor(options, params) {
         super(options, params);
-        logger.debug('initializing write _ADAPTER_NAME_');
+        this.logger.debug('initializing write _ADAPTER_NAME_');
         throw Error('implement me');
     }
 
-    write(points) { 
+    write(points) {
         throw Error('implement me');
     }
 

--- a/test/read.spec.js
+++ b/test/read.spec.js
@@ -1,25 +1,26 @@
 'use strict';
 
 let expect = require('chai').expect;
-let juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+
+let juttle_test_utils = require('juttle/test').utils;
+let configureAdapter = juttle_test_utils.configureAdapter;
 let check_juttle = juttle_test_utils.check_juttle;
 
-let config = [];
-let adapter = require('../lib')(config, Juttle);
-let Juttle = require('juttle/lib/runtime').Juttle;
-Juttle.adapters.register(adapter.name, adapter);
+let config = {};
+config.path = path.resolve(__dirname, '..');
+configureAdapter({_ADAPTER_NAME_: config});
 
-describe('_ADAPTER_NAME_ source', () => {
-  
-    it('reads nothing back', () => {
-        return check_juttle({
-            program: 'read _ADAPTER_NAME_ '
-        })
-        .then(function(result) {
-            expect(result.errors.length).to.equal(0);
-            expect(result.warnings.length).to.equal(0);
-            expect(result.sinks.table[0].length).to.equal(0);
+juttle_test_utils.withAdapterAPI(() => {
+    describe('_ADAPTER_NAME_', () => {
+        it('reads nothing back', () => {
+            return check_juttle({
+                program: 'read _ADAPTER_NAME_ '
+            })
+            .then(function(result) {
+                expect(result.errors.length).to.equal(0);
+                expect(result.warnings.length).to.equal(0);
+                expect(result.sinks.table[0].length).to.equal(0);
+            });
         });
     });
-
 });


### PR DESCRIPTION
The template code was still using require('juttle/...') so fix it to use the global JuttleAdapterAPI.

